### PR TITLE
Fix assertion description

### DIFF
--- a/hw/test/week3_mint/MinterBaseTest.t.sol
+++ b/hw/test/week3_mint/MinterBaseTest.t.sol
@@ -35,7 +35,7 @@ contract MinterBaseTest is Test {
         minterContract.burn(500);
         vm.stopPrank();
         uint256 balance = minterContract.balanceOf(attacker);
-        assertEq(balance, 500, "Burn 1000 tokens");
+        assertEq(balance, 500, "Burn 500 tokens, remains 500 tokens");
     }
 
     function test_transferOwnership() public {


### PR DESCRIPTION
Before:

```solidity=
function test_burn() public {
    vm.startPrank(attacker);
    minterContract.mint(attacker, 1000);
    minterContract.burn(500);
    vm.stopPrank();
    uint256 balance = minterContract.balanceOf(attacker);
    assertEq(balance, 500, "Burn 1000 tokens");
}
```


After:

```solidity=
function test_burn() public {
    vm.startPrank(attacker);
    minterContract.mint(attacker, 1000);
    minterContract.burn(500);
    vm.stopPrank();
    uint256 balance = minterContract.balanceOf(attacker);
    assertEq(balance, 500, "Burn 500 tokens, remains 500 tokens");
}
```